### PR TITLE
reorder files when configuration changes

### DIFF
--- a/src/popup/Popup.svelte
+++ b/src/popup/Popup.svelte
@@ -14,22 +14,24 @@
 
   let isDragging = false;
 
-  function save(items: Entry[]) {
-    const filtered = items.filter((item) => {
+  function save() {
+    const sanitized = items.filter((item) => {
       const isEmptyGlob = item.type === Type.Glob && !item.glob;
       return !isEmptyGlob;
     });
-    dispatch("save", { items: filtered });
+    dispatch("save", { items: sanitized });
   }
 
   function addItem(index: number) {
     items.splice(index, 0, createEntry({ type: Type.Glob }));
     items = items;
+    save();
   }
 
   function removeItem(index: number) {
     items.splice(index, 1);
     items = items;
+    save();
   }
 
   function consider(event: CustomEvent) {
@@ -40,15 +42,12 @@
   function finalize(event: CustomEvent) {
     isDragging = false;
     items = event.detail.items;
+    save();
   }
 
   function transformDraggedElement(draggedEl?: HTMLElement) {
     draggedEl?.querySelector(".add")?.classList.add("dragging");
   }
-
-  // TODO: this saves on keypress when editing a glob. At least
-  // wait until blur, maybe add a Save button
-  $: save(items);
 </script>
 
 <div class="row headings">
@@ -82,11 +81,11 @@
       <form class="row item">
         <IconDrag />
         {#if item.type === Type.Glob}
-          <input aria-label="Glob" bind:value={item.glob} />
+          <input aria-label="Glob" bind:value={item.glob} on:blur={save} />
         {:else}
           <span>All other files</span>
         {/if}
-        <select aria-label="Sort" bind:value={item.sort}>
+        <select aria-label="Sort" bind:value={item.sort} on:change={save}>
           <option value={Sort.Alphabetical}>Alphabetical (default)</option>
           <option value={Sort.MostChanges}>Most changes</option>
           <option value={Sort.FewestChanges}>Fewest changes</option>

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -17,10 +17,22 @@
             items: result.items,
           },
         });
+
         popup.$on("save", async (event) => {
+          const { items } = event.detail;
           await browser.storage.sync.set({
-            items: event.detail.items,
+            items,
           });
+
+          const [tab] = await browser.tabs.query({
+            active: true,
+            lastFocusedWindow: true,
+          });
+          if (tab) {
+            await browser.tabs.sendMessage(tab.id, {
+              items,
+            });
+          }
         });
       })();
     </script>


### PR DESCRIPTION
Sends a message to the current tab to reorder files when the configuration changes:
- On input blur
- On row add/delete
- On sort change

Tried to add an explicit `Save` button but draft states are hard: didn't want to try and support having the popup UI closed but unsaved because it seemed too easy to unintentionally drop changes. So instead all changes are applied and persisted automatically