### PR TITLE
minimatch: enable matchBase to support simpler globs without `/`

### DIFF
--- a/src/content-script/content-script.ts
+++ b/src/content-script/content-script.ts
@@ -31,7 +31,7 @@ function sort(entries: Entry[]) {
         return false;
       }
 
-      return minimatch(path, entry.glob);
+      return minimatch(path, entry.glob, { matchBase: true });
     });
 
     if (index === -1) {


### PR DESCRIPTION
See [docs for `matchBase`](https://github.com/isaacs/minimatch#matchbase): if the pattern does **not** contain a `/`, then it will match against the file basename.

In practice, this means that globs like `*.json` will match _any_ JSON file in the list, without needing `**/*.json`