### PR TITLE
add e2e tests that run against real Github

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -26,5 +26,12 @@ module.exports = {
         parser: "@typescript-eslint/parser",
       },
     },
+    {
+      files: ["e2e/*"],
+      rules: {
+        // playwright fixtures/tests require destructured first argument
+        "no-empty-pattern": "off",
+      },
+    },
   ],
 };

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -9,18 +9,25 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [18.x]
-
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 18
           cache: "npm"
-      - run: npm ci
-      - run: npm run build
-      - run: npm test
+      - name: Install dependencies
+        run: npm ci
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+      - name: Lint
+        run: npm run lint
+      - name: Build extension
+        run: npm run build
+      - name: Run tests
+        run: npm test
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .DS_Store
 node_modules
 dist
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,4 @@
 dist
 package.json
+playwright-report
+test-results

--- a/e2e/extension.test.ts
+++ b/e2e/extension.test.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "./fixtures";
+
+test("extension", async ({ popup, page }) => {
+  await test.step("configure popup: order HTML files first sorted by fewest changes and collapsed", async () => {
+    await popup.getByRole("button", { name: "Add row" }).first().click();
+    await popup.getByRole("textbox", { name: "Glob" }).fill("*.html");
+    await popup
+      .getByRole("combobox", { name: "Sort" })
+      .first()
+      .selectOption("fewest-changes");
+    await popup.getByRole("checkbox", { name: "Collapse" }).first().check();
+  });
+
+  await test.step("check Github comparison view", async () => {
+    await page.goto("https://github.com/YellowKirby/gh-file-sort/pull/7/files");
+    const fileEls = await page
+      .locator("css=.js-file[data-tagsearch-path]")
+      .all();
+    const paths = await Promise.all(
+      fileEls.map((file) => file.getAttribute("data-tagsearch-path"))
+    );
+    expect(paths).toEqual([
+      "src/popup/index.html",
+      "src/content-script/content-script.ts",
+      "src/popup/Popup.svelte",
+    ]);
+  });
+});

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,29 @@
+import { test as base, chromium, BrowserContext, Page } from "@playwright/test";
+import path from "path";
+
+export const test = base.extend<{
+  context: BrowserContext;
+  popup: Page;
+}>({
+  // https://playwright.dev/docs/chrome-extensions
+  context: async ({}, use) => {
+    const pathToExtension = path.resolve(process.cwd(), "./dist");
+    const context = await chromium.launchPersistentContext("", {
+      headless: false,
+      args: [
+        process.env.PWDEBUG ? "" : "--headless=new",
+        `--disable-extensions-except=${pathToExtension}`,
+        `--load-extension=${pathToExtension}`,
+      ],
+    });
+    await use(context);
+    await context.close();
+  },
+  popup: async ({ page }, use) => {
+    await page.goto(
+      `chrome-extension://fncgajbgcdgennojcoeoadgekedmkfoc/src/popup/index.html`
+    );
+    await use(page);
+  },
+});
+export const expect = test.expect;

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "webextension-polyfill": "^0.10.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.35.1",
         "@samrum/vite-plugin-web-extension": "^5.0.0",
         "@storybook/addon-essentials": "^7.0.14",
         "@storybook/svelte": "^7.0.14",
@@ -27,6 +28,7 @@
         "eslint-plugin-svelte": "^2.29.0",
         "husky": "^8.0.3",
         "lint-staged": "^13.2.2",
+        "playwright-webextext": "^0.0.3",
         "prettier": "^2.8.8",
         "prettier-plugin-svelte": "^2.10.1",
         "storybook": "^7.0.14",
@@ -2918,6 +2920,25 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.35.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.35.1.tgz",
+      "integrity": "sha512-b5YoFe6J9exsMYg0pQAobNDR85T1nLumUYgUTtKm4d21iX2L7WqKq9dW8NGJ+2vX0etZd+Y7UeuqsxDXm9+5ZA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "playwright-core": "1.35.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -13736,6 +13757,58 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.26.0.tgz",
+      "integrity": "sha512-XxTVlvFEYHdatxUkh1KiPq9BclNtFKMi3BgQnl/aactmhN4G9AkZUXwt0ck6NDAOrDFlfibhbM7A1kZwQJKSBw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "peer": true,
+      "dependencies": {
+        "playwright-core": "1.26.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.35.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.35.1.tgz",
+      "integrity": "sha512-pNXb6CQ7OqmGDRspEjlxE49w+4YtR6a3X6mT1hZXeJHWmsEz7SunmvZeiG/+y1yyMZdHnnn73WKYdtV1er0Xyg==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/playwright-webextext": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/playwright-webextext/-/playwright-webextext-0.0.3.tgz",
+      "integrity": "sha512-qcnMZES3vbnEfCrOobsaFrT+BBlRgCmKBCzhoRxPkdC9C5KSOYdROikuTHRoe/ez5v1Eh02szQjwRBStOkDF6g==",
+      "dev": true,
+      "peerDependencies": {
+        "@playwright/test": "1.26.0",
+        "playwright": "1.26.0"
+      }
+    },
+    "node_modules/playwright/node_modules/playwright-core": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.26.0.tgz",
+      "integrity": "sha512-p8huU8eU4gD3VkJd3DA1nA7R3XA6rFvFL+1RYS96cSljCF2yJE9CWEHTPF4LqX8KN9MoWCrAfVKP5381X3CZqg==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/polished": {

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "prepare": "husky install",
-    "test": "npm run lint && prettier --check .",
-    "lint": "eslint .",
-    "lint:fix": "npm run lint -- --fix"
+    "test": "playwright test",
+    "lint": "eslint . && prettier --check .",
+    "lint:fix": "eslint --fix . && prettier --write ."
   },
   "type": "module",
   "license": "MIT",
@@ -23,6 +23,7 @@
     "webextension-polyfill": "^0.10.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.35.1",
     "@samrum/vite-plugin-web-extension": "^5.0.0",
     "@storybook/addon-essentials": "^7.0.14",
     "@storybook/svelte": "^7.0.14",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+  use: {
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -7,6 +7,12 @@ export function getManifest(): chrome.runtime.ManifestV3 {
     description: pkg.description,
     name: pkg.name,
     version: pkg.version,
+    // Dummy key so that we get a stable extension ID for playwright tests.
+    // TODO: Use a real ID if this ever publishes to Chrome Web Store
+    // https://stackoverflow.com/questions/23873623/obtaining-chrome-extension-id-for-development
+    //
+    // extensionId for this key: fncgajbgcdgennojcoeoadgekedmkfoc
+    key: "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmtdV/ts5+pcOAM3AP9csVIukGgFBWDLJZQrT4txjNSlqkwzEgQXY28JMyWNm6oa4uHL/eTECy2nDGjWApT2SbrwggD+R+g/a9MvkGlRp5dayUX3B0VHYIqSN1nr/7ErUX0ohaRR46KAd0PN1NK1tYXDnGRRhKNPo+BOH/YP0iRdVOAyUBXUcoWrFXT5vQlBFeuDTfwjE0vhozslxQUDtRpcRJ8QLXKhk7H5fxHVXdDtBN0i89ftPemAOFHB6iNpARJzGfq4+cUaCgbY/CLNrIGbppRZ9c4yf3ziFzpIy1zyIJTkR1Wfh6hl6pv5/YI+CPgRJAybwwGxuBT/ApcT51wIDAQAB",
     content_scripts: [
       {
         js: ["src/content-script/content-script.ts"],


### PR DESCRIPTION
Since the content-script for this extension relies on Github's DOM, it'd be nice to know if/when that changes. Plus Playwright makes me happy.

e2e tests only run in Chrome at the moment. Didn't spend too much time trying to get this to work with Firefox because [it looks like it's still an open issue](https://github.com/microsoft/playwright/issues/7297).