### PR TITLE
ci: add workflow steps to manually trigger a semver'd release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: CI Build
+name: Build
 
 on:
   push:
@@ -22,6 +22,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -32,6 +35,20 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # kinda awkward: we re-use the same job for build and releases
+      # because the release version bump needs to happen before the build
+      # (new build number gets used in the manifest.json) and conditionally
+      # skip releasy steps for regular CI builds.
+      #
+      # alternatives:
+      #   - separate build + release jobs: I think this requires uploading
+      #   an artifact of the entire workspace, because it's not re-used
+      #   between jobs: https://stackoverflow.com/questions/57498605/github-actions-share-workspace-artifacts-between-jobs
+      #
+      #   - separate workflows: Sounds ideal, but same limitation as above... or requires duplication
+      #   or building twice: https://docs.github.com/en/actions/using-workflows/reusing-workflows
+      #
+      #   - composite action for build: seems to work, but the UI hides all the sub-steps :(
       - name: Bump package.json version (only for releases)
         if: inputs.release-type && inputs.release-type != 'none'
         run: |

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -12,9 +12,7 @@ on:
       release-type:
         description: "Semver version bump type"
         type: choice
-        default: none
         options:
-          - none
           - patch
           - minor
           - major
@@ -33,7 +31,7 @@ jobs:
         run: npm ci
 
       - name: Bump package.json version
-        if: ${{ inputs.release-type != 'none' }}
+        if: inputs.release-type
         run: npm version ${{ inputs.release-type }}
 
       - name: Get variables
@@ -80,7 +78,7 @@ jobs:
           path: dist/
 
       - name: Push changes
-        if: ${{ inputs.release-type != 'none' }}
+        if: inputs.release-type
         uses: ad-m/github-push-action@v0.6.0
         with:
           tags: true

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,19 +1,41 @@
 name: CI Build
 
 on:
-  workflow_call:
   push:
     branches: [main]
   pull_request:
     branches: [main]
   schedule:
     - cron: "0 8 * * *"
+  workflow_dispatch:
+    inputs:
+      release-type:
+        description: "Semver version bump type"
+        type: choice
+        options:
+          - none
+          - patch
+          - minor
+          - major
 
 jobs:
-  build:
+  checkout:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+  version:
+    runs-on: ubuntu-latest
+    needs: checkout
+    if: ${{ inputs.release-type != 'none' }}
+    steps:
+      - name: Bump package.json version
+        run: npm version ${{ inputs.release-type }}
+
+  build:
+    runs-on: ubuntu-latest
+    needs: checkout
+    steps:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
@@ -64,3 +86,13 @@ jobs:
         with:
           name: ${{ steps.get-vars.outputs.pkg-name }}-${{ steps.get-vars.outputs.short-sha }}
           path: dist/
+
+  release:
+    needs: [version, build]
+    runs-on: ubuntu-latest
+    if: ${{ inputs.release-type != 'none' }}
+    steps:
+      - name: Push changes
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          tags: true

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -12,7 +12,9 @@ on:
       release-type:
         description: "Semver version bump type"
         type: choice
+        default: none
         options:
+          - none (build only)
           - patch
           - minor
           - major
@@ -30,9 +32,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Bump package.json version
-        if: inputs.release-type
-        run: npm version ${{ inputs.release-type }}
+      - name: Bump package.json version (only for releases)
+        if: inputs.release-type && inputs.release-type != 'none'
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          npm version ${{ inputs.release-type }}
 
       - name: Get variables
         id: get-vars
@@ -77,8 +82,8 @@ jobs:
           name: ${{ steps.get-vars.outputs.pkg-name }}-${{ steps.get-vars.outputs.short-sha }}
           path: dist/
 
-      - name: Push changes
-        if: inputs.release-type
+      - name: Push tags (only for releases)
+        if: inputs.release-type && inputs.release-type != 'none'
         uses: ad-m/github-push-action@v0.6.0
         with:
           tags: true

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -14,7 +14,7 @@ on:
         type: choice
         default: none
         options:
-          - none (build only)
+          - none
           - patch
           - minor
           - major

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -86,4 +86,6 @@ jobs:
         if: inputs.release-type && inputs.release-type != 'none'
         uses: ad-m/github-push-action@v0.6.0
         with:
+          github_token: ${{ github.token }}
+          branch: ${{ github.ref }}
           tags: true

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -12,6 +12,7 @@ on:
       release-type:
         description: "Semver version bump type"
         type: choice
+        default: none
         options:
           - none
           - patch
@@ -19,23 +20,10 @@ on:
           - major
 
 jobs:
-  checkout:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-  version:
-    runs-on: ubuntu-latest
-    needs: checkout
-    if: ${{ inputs.release-type != 'none' }}
-    steps:
-      - name: Bump package.json version
-        run: npm version ${{ inputs.release-type }}
-
-  build:
-    runs-on: ubuntu-latest
-    needs: checkout
-    steps:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
@@ -43,6 +31,10 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Bump package.json version
+        if: ${{ inputs.release-type != 'none' }}
+        run: npm version ${{ inputs.release-type }}
 
       - name: Get variables
         id: get-vars
@@ -87,12 +79,8 @@ jobs:
           name: ${{ steps.get-vars.outputs.pkg-name }}-${{ steps.get-vars.outputs.short-sha }}
           path: dist/
 
-  release:
-    needs: [version, build]
-    runs-on: ubuntu-latest
-    if: ${{ inputs.release-type != 'none' }}
-    steps:
       - name: Push changes
+        if: ${{ inputs.release-type != 'none' }}
         uses: ad-m/github-push-action@v0.6.0
         with:
           tags: true


### PR DESCRIPTION
The goal:
- `npm version` to do a semver-bump of the `package.json#version`. This happens first because the extension `manifest.json` pulls this value on build
- build it!
- push the commit + tag from `npm version` back to Github

Assuming it all works, making a Github Release off the tag (with release notes! :memo:) will probably happen in another PR